### PR TITLE
Upgrade to support OTP 26+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Set up Elixir environment
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "24"
-          elixir-version: "1.14"
+          otp-version: "27"
+          elixir-version: "1.18"
 
       - name: Check unused dependencies
         run: mix deps.get && mix deps.unlock --check-unused

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         versions:
           - otp: "24"
             elixir: "1.14"
+          - otp: "25"
+            elixir: "1.18"
           - otp: "26"
             elixir: "1.18"
           - otp: "27"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
         versions:
           - otp: "24"
             elixir: "1.14"
+          - otp: "26"
+            elixir: "1.18"
+          - otp: "27"
+            elixir: "1.18"
 
     env:
       MIX_ENV: test

--- a/lib/fluxter.ex
+++ b/lib/fluxter.ex
@@ -162,12 +162,12 @@ defmodule Fluxter do
   @doc """
   Should be the same as `measure(measurement, [], [], fun_or_mfa)`.
   """
-  @callback measure(measurement, (() -> result) | mfa()) :: result when result: var
+  @callback measure(measurement, (-> result) | mfa()) :: result when result: var
 
   @doc """
   Should be the same as `measure(measurement, tags, [], fun_or_mfa)`.
   """
-  @callback measure(measurement, tags, (() -> result) | mfa()) :: result when result: var
+  @callback measure(measurement, tags, (-> result) | mfa()) :: result when result: var
 
   @doc """
   Measures the execution time of `fun_or_mfa` and writes it as a metric.
@@ -195,7 +195,7 @@ defmodule Fluxter do
       2
 
   """
-  @callback measure(measurement, tags, fields, (() -> result) | mfa()) :: result when result: var
+  @callback measure(measurement, tags, fields, (-> result) | mfa()) :: result when result: var
 
   @doc """
   Should be the same as `start_counter(measurement, [], [])`.
@@ -300,10 +300,7 @@ defmodule Fluxter do
 
         config = Fluxter.get_config(__MODULE__, options)
 
-        conn =
-          config.host
-          |> Fluxter.Conn.new(config.port)
-          |> Map.update!(:header, &[&1 | config.prefix])
+        conn = Fluxter.Conn.new(config.host, config.port, config.prefix)
 
         @worker_names
         |> Enum.map(fn name ->

--- a/lib/fluxter/packet.ex
+++ b/lib/fluxter/packet.ex
@@ -1,36 +1,10 @@
 defmodule Fluxter.Packet do
   @moduledoc false
 
-  import Bitwise
-
-  otp_release = :erlang.system_info(:otp_release)
-  @addr_family if(otp_release >= '19', do: [1], else: [])
-
-  def header({n1, n2, n3, n4}, port) do
-    true = Code.ensure_loaded?(:gen_udp)
-
-    anc_data_part =
-      if function_exported?(:gen_udp, :send, 5) do
-        [0, 0, 0, 0]
-      else
-        []
-      end
-
-    @addr_family ++
-      [
-        band(bsr(port, 8), 0xFF),
-        band(port, 0xFF),
-        band(n1, 0xFF),
-        band(n2, 0xFF),
-        band(n3, 0xFF),
-        band(n4, 0xFF)
-      ] ++ anc_data_part
-  end
-
-  def build(header, name, tags, fields) do
+  def build(prefix, name, tags, fields) do
     tags = encode_tags(tags)
     fields = encode_fields(fields)
-    [header, encode_key(name), tags, ?\s, fields]
+    [encode_key(prefix), encode_key(name), tags, ?\s, fields]
   end
 
   defp encode_tags([]), do: ""
@@ -48,7 +22,7 @@ defmodule Fluxter.Packet do
   end
 
   defp encode_key(val) do
-    to_string(val) |> escape(' ,')
+    val |> to_string() |> escape(~c" ,")
   end
 
   defp encode_value(val) do
@@ -63,7 +37,7 @@ defmodule Fluxter.Packet do
         Atom.to_string(val)
 
       is_binary(val) ->
-        [?\", escape(val, '"'), ?\"]
+        [?\", escape(val, ~c"\""), ?\"]
     end
   end
 


### PR DESCRIPTION
This is a fix for an error with Fluxter and ERTS >= 10.5.3. Originally, Fluxter would include a hardcoded binary header to each write. This header contains the binary representation of the destination IP address, port, and optionally a prefix. The write itself was being issued as a plain `send` to the port that was failing with error `einval`. It is possible that there was a change in the way ERTS expects this header to be formatted. This PR patches Fluxter to use `:gen_udp.send/4` and drop the binary header to fix the issue.